### PR TITLE
Housekeeping function to prevent infinite database growth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ metrics-core = { version = "^0.5" }
 metrics-util = { version = "^0.3" }
 hdrhistogram = { version = "^6.3", default-features = false }
 thiserror = "1.0.20"
+log = "0.4.11"
 
 [dev-dependencies]
 metrics-runtime = { version = "0.13.1", default-features = false }
 metrics = "0.12.1"
+pretty_env_logger = "0.4"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -13,7 +13,7 @@ fn setup_metrics() {
             receiver.controller(),
             SqliteBuilder::new(),
             Duration::from_secs(5),
-            Duration::from_secs(60 * 60 * 24 * 7), // 60s * 60min * 24 hours * 7 days
+            Some(Duration::from_secs(60 * 60 * 24 * 7)), // 60 sec * 60 min * 24 hours * 7 days
             "metrics.db",
         )
         .expect("Failed to create SqliteExporter");

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -13,6 +13,7 @@ fn setup_metrics() {
             receiver.controller(),
             SqliteBuilder::new(),
             Duration::from_secs(5),
+            Duration::from_secs(60 * 60 * 24 * 7), // 60s * 60min * 24 hours * 7 days
             "metrics.db",
         )
         .expect("Failed to create SqliteExporter");
@@ -21,6 +22,9 @@ fn setup_metrics() {
     });
 }
 fn main() {
+    pretty_env_logger::formatted_builder()
+        .filter(None, log::LevelFilter::Trace)
+        .init();
     setup_metrics();
     loop {
         counter!("video.counter", 1);


### PR DESCRIPTION
- `SqliteExporter::new()` has new argument for duration of how long to keep data stored
- `SqliteExporter::housekeeping()` for manually calling cleanup
- `SqliteExporter::run()` will run housekeeping before entering the interval loop