### PR TITLE
feature: metrics 0.14 & ability to flush to disk less

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics-sqlite"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jeremy Knope <jeremy@astropad.com>"]
 description = "Library for providing SQLite backend for metrics"
 keywords = ["metrics", "sqlite"]
@@ -10,17 +10,14 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-diesel = { version = "1.4.5", features = ["sqlite"] }
-diesel_migrations = "1.4.0"
-# this seems to let us force bundled sqlite in disel
-libsqlite3-sys = { version = "0.18.0", features = ["bundled"] }
-metrics-core = { version = "^0.5" }
-metrics-util = { version = "^0.3" }
-hdrhistogram = { version = "^6.3", default-features = false }
-thiserror = "1.0.20"
-log = "0.4.11"
+diesel = { version = "1.4", features = ["sqlite"] }
+diesel_migrations = "1.4"
+# this seems to let us force bundled sqlite in diesel
+libsqlite3-sys = { version = "0.18", features = ["bundled"] }
+metrics = { version = "0.14" }
+thiserror = "1.0"
+log = "0.4"
 
 [dev-dependencies]
-metrics-runtime = { version = "0.13.1", default-features = false }
-metrics = "0.12.1"
+metrics = "0.14"
 pretty_env_logger = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,9 @@ diesel = { version = "1.4", features = ["sqlite"] }
 diesel_migrations = "1.4"
 # this seems to let us force bundled sqlite in diesel
 libsqlite3-sys = { version = "0.18", features = ["bundled"] }
-metrics = { version = "0.14" }
+metrics = "0.14"
 thiserror = "1.0"
 log = "0.4"
 
 [dev-dependencies]
-metrics = "0.14"
 pretty_env_logger = "0.4"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -19,6 +19,8 @@ fn main() {
         .filter(None, log::LevelFilter::Trace)
         .init();
     setup_metrics();
+    metrics::register_counter!("video.counter");
+    metrics::register_gauge!("net.quality.rate", metrics::Unit::MegabitsPerSecond);
     loop {
         counter!("video.counter", 1);
         counter!("net.packets", 2);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,25 +1,18 @@
-use metrics::{counter, gauge, timing};
-use metrics_runtime::Receiver;
-use metrics_sqlite::{SqliteBuilder, SqliteExporter};
+use metrics::{counter, gauge};
+// use metrics_runtime::Receiver;
+use metrics_sqlite::SqliteExporter;
 use std::time::Duration;
 
 fn setup_metrics() {
-    std::thread::spawn(move || {
-        let receiver = Receiver::builder()
-            .build()
-            .expect("failed to create receiver");
-
-        let mut exporter = SqliteExporter::new(
-            receiver.controller(),
-            SqliteBuilder::new(),
-            Duration::from_secs(5),
-            Some(Duration::from_secs(60 * 60 * 24 * 7)), // 60 sec * 60 min * 24 hours * 7 days
-            "metrics.db",
-        )
-        .expect("Failed to create SqliteExporter");
-        receiver.install();
-        exporter.run();
-    });
+    let exporter = SqliteExporter::new(
+        Duration::from_secs(30),
+        Some(Duration::from_secs(60 * 60 * 24 * 7)), // 60 sec * 60 min * 24 hours * 7 days
+        "metrics.db",
+    )
+    .expect("Failed to create SqliteExporter");
+    exporter
+        .install()
+        .expect("Failed to install SqliteExporter");
 }
 fn main() {
     pretty_env_logger::formatted_builder()
@@ -29,9 +22,9 @@ fn main() {
     loop {
         counter!("video.counter", 1);
         counter!("net.packets", 2);
-        gauge!("net.quality.rate", 231);
-        let start = std::time::Instant::now();
-        std::thread::sleep(Duration::from_millis(500));
-        timing!("net.time.delay", start, std::time::Instant::now());
+        gauge!("net.quality.rate", 231.2);
+        // let start = std::time::Instant::now();
+        std::thread::sleep(Duration::from_millis(100));
+        // timing!("net.time.delay", start, std::time::Instant::now());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ fn run_worker(
             use crate::schema::metrics::dsl::metrics;
             trace!("Flushing {} records", queue.len());
             db.transaction::<_, diesel::result::Error, _>(|| {
-                for rec in queue.drain(0..) {
+                for rec in queue.drain(..) {
                     insert_into(metrics).values(&rec).execute(db)?;
                 }
                 Ok(())

--- a/src/models.rs
+++ b/src/models.rs
@@ -10,7 +10,7 @@ pub struct NewMetric {
     /// Key/name of sample
     pub key: String,
     /// Value of sample
-    pub value: i64,
+    pub value: f64,
 }
 
 /// Metric model for existing entries in sqlite database
@@ -23,5 +23,5 @@ pub struct Metric {
     /// Key/name of sample
     pub key: String,
     /// Value of sample
-    pub value: i64,
+    pub value: f64,
 }

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -3,19 +3,18 @@ use metrics::{GaugeValue, Key, Recorder, Unit};
 use std::time::SystemTime;
 
 impl Recorder for SqliteExporter {
-    fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
-        println!("Registering counter: {} {:?} {:?}", key, unit, description);
+    // in future we could record these to the SQLite database for informational/metadata usage
+    fn register_counter(&self, _key: Key, _unit: Option<Unit>, _description: Option<&'static str>) {
     }
 
-    fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
-        println!("Registering gauge: {} {:?} {:?}", key, unit, description);
-    }
+    fn register_gauge(&self, _key: Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
 
-    fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
-        println!(
-            "Registering histogram: {} {:?} {:?}",
-            key, unit, description
-        );
+    fn register_histogram(
+        &self,
+        _key: Key,
+        _unit: Option<Unit>,
+        _description: Option<&'static str>,
+    ) {
     }
 
     fn increment_counter(&self, key: Key, value: u64) {

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -1,0 +1,89 @@
+use crate::{Event, NewMetric, SqliteExporter};
+use metrics::{GaugeValue, Key, Recorder, Unit};
+use std::time::SystemTime;
+
+impl Recorder for SqliteExporter {
+    fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+        println!("Registering counter: {} {:?} {:?}", key, unit, description);
+    }
+
+    fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+        println!("Registering gauge: {} {:?} {:?}", key, unit, description);
+    }
+
+    fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+        println!(
+            "Registering histogram: {} {:?} {:?}",
+            key, unit, description
+        );
+    }
+
+    fn increment_counter(&self, key: Key, value: u64) {
+        let timestamp = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs_f64();
+        let mut counters = self.counters.borrow_mut();
+        let key_str = key.name().to_string();
+        let entry = counters.entry(key).or_insert(0);
+        let value = {
+            *entry = *entry + value;
+            *entry
+        };
+        let metric = NewMetric {
+            timestamp,
+            key: key_str,
+            value: value as _,
+        };
+        if let Err(e) = self.sender.try_send(Event::Metric(metric)) {
+            error!("Error sending metric to SQLite thread: {}", e);
+        }
+    }
+
+    fn update_gauge(&self, key: Key, value: GaugeValue) {
+        let timestamp = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs_f64();
+        let mut last_values = self.last_values.borrow_mut();
+        let key_str = key.name().to_string();
+        let entry = last_values.entry(key).or_insert(0.0);
+        let value = match value {
+            GaugeValue::Absolute(v) => {
+                *entry = v;
+                *entry
+            }
+            GaugeValue::Increment(v) => {
+                *entry = *entry + v;
+                *entry
+            }
+            GaugeValue::Decrement(v) => {
+                *entry = *entry - v;
+                *entry
+            }
+        };
+
+        let metric = NewMetric {
+            timestamp,
+            key: key_str,
+            value,
+        };
+        if let Err(e) = self.sender.try_send(Event::Metric(metric)) {
+            error!("Error sending metric to SQLite thread: {}", e);
+        }
+    }
+
+    fn record_histogram(&self, key: Key, value: f64) {
+        let timestamp = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs_f64();
+        let mut last_values = self.last_values.borrow_mut();
+        let key_str = key.name().to_string();
+        let entry = last_values.entry(key).or_insert(0.0);
+        let value = {
+            *entry = value;
+            *entry
+        };
+
+        let metric = NewMetric {
+            timestamp,
+            key: key_str,
+            value,
+        };
+        if let Err(e) = self.sender.try_send(Event::Metric(metric)) {
+            error!("Error sending metric to SQLite thread: {}", e);
+        }
+    }
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -3,7 +3,7 @@ table! {
         id -> BigInt,
         timestamp -> Double,
         key -> Text,
-        value -> BigInt,
+        value -> Double,
     }
 }
 


### PR DESCRIPTION
- Allows less frequent writing to disk by doing a single transaction batch on a flush timeout interval
- Upgrades to `metrics` 0.14 which has float support & simpler API

## Todo

- [x] Cleanup, document etc