### PR TITLE
Fix panics due to multi-threaded metrics use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics-sqlite"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Jeremy Knope <jeremy@astropad.com>"]
 description = "Library for providing SQLite backend for metrics"
 keywords = ["metrics", "sqlite"]


### PR DESCRIPTION
Multiple threads calling SqliteExporter's recorder would panic due to #5 so moved that logic to the worker thread.

Also guarded against possible SystemTime errors so we don't panic on that.