### PR TITLE
CSV Export feature for MetricsDb type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ pretty_env_logger = "0.4"
 [features]
 default = []
 export_csv = ["csv", "serde/derive"]
+
+[[example]]
+name = "export_csv"
+required-features = ["export_csv"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ pretty_env_logger = "0.4"
 
 [features]
 default = []
-csv_export = ["csv", "serde/derive"]
+export_csv = ["csv", "serde/derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics-sqlite"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Jeremy Knope <jeremy@astropad.com>"]
 description = "Library for providing SQLite backend for metrics"
 keywords = ["metrics", "sqlite"]
@@ -19,6 +19,12 @@ libsqlite3-sys = { version = "0.18", features = ["bundled"] }
 metrics = "0.14"
 thiserror = "1.0"
 log = "0.4"
+csv = {version = "1.1.6", optional = true }
+serde = { version = "1.0.125", optional = true }
 
 [dev-dependencies]
 pretty_env_logger = "0.4"
+
+[features]
+default = []
+csv_export = ["csv", "serde/derive"]

--- a/examples/export_csv.rs
+++ b/examples/export_csv.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let db = metrics_sqlite::MetricsDb::new("metrics.db").expect("Failed to open DB");
+    db.export_to_csv("metrics.csv")
+        .expect("Failed to export to CSV");
+}

--- a/src/metrics_db.rs
+++ b/src/metrics_db.rs
@@ -123,4 +123,19 @@ impl MetricsDb {
             .collect();
         Ok(new_values)
     }
+
+    /// Exports DB contents to CSV file
+    #[cfg(feature = "csv")]
+    pub fn export_to_csv<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        use crate::schema::metrics::dsl::*;
+        use std::fs::File;
+        let out_file = File::create(path)?;
+        let mut csv_writer = csv::Writer::from_writer(out_file);
+        let query = metrics.order(timestamp.asc());
+        for row in query.load::<Metric>(&self.db)? {
+            csv_writer.serialize(row)?;
+        }
+        csv_writer.flush()?;
+        Ok(())
+    }
 }

--- a/src/metrics_db.rs
+++ b/src/metrics_db.rs
@@ -125,7 +125,7 @@ impl MetricsDb {
     }
 
     /// Exports DB contents to CSV file
-    #[cfg(feature = "csv")]
+    #[cfg(feature = "export_csv")]
     pub fn export_to_csv<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         use crate::schema::metrics::dsl::*;
         use std::fs::File;

--- a/src/models.rs
+++ b/src/models.rs
@@ -15,6 +15,7 @@ pub struct NewMetric {
 
 /// Metric model for existing entries in sqlite database
 #[derive(Queryable, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Metric {
     /// Unique ID of sample
     pub id: i64,


### PR DESCRIPTION
just requires feature flag `export_csv` to be enabled

this lets you easily get a more compressible version of the db if desired.