### PR TITLE
Reduce SQLite file size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics-sqlite"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Jeremy Knope <jeremy@astropad.com>"]
 description = "Library for providing SQLite backend for metrics"
 keywords = ["metrics", "sqlite"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ pretty_env_logger = "0.4"
 
 [features]
 default = []
+log_dropped_metrics = []
 export_csv = ["csv", "serde/derive"]
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 
 This provides a fairly simple SQLite powered backend for the [metrics](https://crates.io/crates/metrics) crate, useful for offline or desktop applications to gather metrics that can be easily queried afterwards.
 
+## Version 0.3 Notes
+
+- Now vacuums on setup which can incur a delay in being ready to record
+- Migration of database blows away 0.2 data unfortunately
+
 ## Example
 
 ```Rust

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -4,7 +4,7 @@ fn main() {
     let db = MetricsDb::new("metrics.db").unwrap();
     println!("Keys: {}", db.available_keys().unwrap().join(", "));
     let sessions = db.sessions();
-    for (i, s) in sessions.into_iter().enumerate() {
+    for (i, s) in sessions.iter().enumerate() {
         println!(
             "Session {}: {:.2}s long ({:.2} - {:.2})",
             i + 1,

--- a/examples/large-file.rs
+++ b/examples/large-file.rs
@@ -19,7 +19,11 @@ fn main() {
         .init();
     setup_metrics();
     metrics::register_counter!("video.counter");
-    metrics::register_gauge!("net.quality.rate", metrics::Unit::MegabitsPerSecond);
+    metrics::register_gauge!(
+        "net.quality.rate",
+        metrics::Unit::MegabitsPerSecond,
+        "Quality's bit rate"
+    );
 
     loop {
         gauge!("rate_control.previous_metered_throughput", 2134.0);

--- a/examples/large-file.rs
+++ b/examples/large-file.rs
@@ -9,13 +9,14 @@ fn setup_metrics() {
         "metrics-large.db",
     )
     .expect("Failed to create SqliteExporter");
+    exporter.set_periodic_housekeeping(Some(Duration::from_secs(10)), None, Some(1_000_000));
     exporter
         .install()
         .expect("Failed to install SqliteExporter");
 }
 fn main() {
     pretty_env_logger::formatted_builder()
-        .filter(None, log::LevelFilter::Info)
+        .filter(None, log::LevelFilter::Trace)
         .init();
     setup_metrics();
     metrics::register_counter!("video.counter");
@@ -34,7 +35,7 @@ fn main() {
         counter!("net.packets", 2);
         gauge!("net.quality.rate", 231.2);
         // let start = std::time::Instant::now();
-        std::thread::sleep(Duration::from_micros(500));
+        std::thread::sleep(Duration::from_micros(1000));
         // timing!("net.time.delay", start, std::time::Instant::now());
     }
 }

--- a/examples/large-file.rs
+++ b/examples/large-file.rs
@@ -1,0 +1,36 @@
+use metrics::{counter, gauge};
+use metrics_sqlite::SqliteExporter;
+use std::time::Duration;
+
+fn setup_metrics() {
+    let exporter = SqliteExporter::new(
+        Duration::from_millis(250),
+        Some(Duration::from_secs(60 * 60 * 24 * 7)), // 60 sec * 60 min * 24 hours * 7 days
+        "metrics-large.db",
+    )
+    .expect("Failed to create SqliteExporter");
+    exporter
+        .install()
+        .expect("Failed to install SqliteExporter");
+}
+fn main() {
+    pretty_env_logger::formatted_builder()
+        .filter(None, log::LevelFilter::Info)
+        .init();
+    setup_metrics();
+    metrics::register_counter!("video.counter");
+    metrics::register_gauge!("net.quality.rate", metrics::Unit::MegabitsPerSecond);
+
+    loop {
+        gauge!("rate_control.previous_metered_throughput", 2134.0);
+        gauge!("rate_control.metered_throughput", 2134.0);
+        gauge!("rate_control.smoothed_rtt", 2133.0);
+        gauge!("rate_control.raw_rtt", 2341.0);
+        counter!("video.counter", 1);
+        counter!("net.packets", 2);
+        gauge!("net.quality.rate", 231.2);
+        // let start = std::time::Instant::now();
+        std::thread::sleep(Duration::from_micros(500));
+        // timing!("net.time.delay", start, std::time::Instant::now());
+    }
+}

--- a/migrations/2022-01-19-204521_create_metric_keys/down.sql
+++ b/migrations/2022-01-19-204521_create_metric_keys/down.sql
@@ -1,0 +1,11 @@
+DROP INDEX metrics_keys_key_idx;
+DROP TABLE metric_keys;
+DROP TABLE metrics;
+CREATE TABLE IF NOT EXISTS metrics (
+                                       id integer NOT NULL primary key autoincrement,
+                                       timestamp real NOT NULL,
+                                       key text NOT NULL,
+                                       value integer NOT NULL
+);
+CREATE INDEX IF NOT EXISTS metrics_timestamp_idx ON metrics (timestamp);
+CREATE INDEX IF NOT EXISTS metrics_key_idx ON metrics (key);

--- a/migrations/2022-01-19-204521_create_metric_keys/up.sql
+++ b/migrations/2022-01-19-204521_create_metric_keys/up.sql
@@ -11,6 +11,7 @@ CREATE INDEX IF NOT EXISTS metrics_key_id_idx ON metrics (metric_key_id);
 CREATE TABLE IF NOT EXISTS metric_keys (
                                        id integer NOT NULL primary key autoincrement,
                                        key text NOT NULL,
-                                       unit text
+                                       unit text,
+                                       description text
 );
 CREATE INDEX IF NOT EXISTS metrics_keys_key_idx ON metric_keys (key);

--- a/migrations/2022-01-19-204521_create_metric_keys/up.sql
+++ b/migrations/2022-01-19-204521_create_metric_keys/up.sql
@@ -1,0 +1,16 @@
+DROP TABLE metrics;
+CREATE TABLE IF NOT EXISTS metrics (
+                                       id integer NOT NULL primary key autoincrement,
+                                       timestamp real NOT NULL,
+                                       metric_key_id integer NOT NULL,
+                                       value integer NOT NULL
+);
+CREATE INDEX IF NOT EXISTS metrics_timestamp_idx ON metrics (timestamp);
+CREATE INDEX IF NOT EXISTS metrics_key_id_idx ON metrics (metric_key_id);
+
+CREATE TABLE IF NOT EXISTS metric_keys (
+                                       id integer NOT NULL primary key autoincrement,
+                                       key text NOT NULL,
+                                       unit text
+);
+CREATE INDEX IF NOT EXISTS metrics_keys_key_idx ON metric_keys (key);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,7 +319,8 @@ impl SqliteExporter {
 
     /// Sets optional periodic house keeping, None to disable (disabled by default)
     /// ## Notes
-    /// Periodic house keeping can affect metric recording, causing some data to be dropped during
+    /// Periodic house keeping can affect metric recording, causing some data to be dropped during house keeping.
+    /// Record limit if set will cause anything over limit + 25% of limit to be removed
     pub fn set_periodic_housekeeping(
         &self,
         periodic_duration: Option<Duration>,

--- a/src/metrics_db.rs
+++ b/src/metrics_db.rs
@@ -117,7 +117,7 @@ impl MetricsDb {
         let keys = query.load::<MetricKey>(&self.db)?;
         keys.into_iter()
             .next()
-            .ok_or(MetricsError::KeyNotFound(key_name.to_string()))
+            .ok_or_else(|| MetricsError::KeyNotFound(key_name.to_string()))
     }
 
     /// Returns rate of change, the derivative, of the given metrics key's values

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,7 @@
 //! Diesel models of metrics sqlite storage
 use crate::schema::{metric_keys, metrics};
 use crate::{MetricsError, Result};
+use ::metrics::Unit;
 use diesel::prelude::*;
 use std::borrow::Cow;
 
@@ -24,6 +25,8 @@ pub struct NewMetricKey<'a> {
     pub key: Cow<'a, str>,
     /// Unit if any
     pub unit: Cow<'a, str>,
+    /// Description of metric key if any
+    pub description: Cow<'a, str>,
 }
 
 /// Metric key
@@ -36,8 +39,38 @@ pub struct MetricKey<'a> {
     pub key: Cow<'a, str>,
     /// Unit if any
     pub unit: Cow<'a, str>,
+    /// Description of metric key if any
+    pub description: Cow<'a, str>,
 }
 impl<'a> MetricKey<'a> {
+    pub(crate) fn create_or_update(
+        key_name: &str,
+        unit: Option<Unit>,
+        description: Option<&'a str>,
+        db: &SqliteConnection,
+    ) -> Result<MetricKey<'a>> {
+        let key = Self::key_by_name(key_name, db)?;
+        let unit_value = unit
+            .map(|u| Cow::Owned(u.as_str().to_string()))
+            .unwrap_or(Cow::Borrowed(""));
+        let description = description
+            .map(|u| Cow::Borrowed(u))
+            .unwrap_or(Cow::Borrowed(""));
+        Self::update(key.id, unit_value, description, db)?;
+        Ok(key)
+    }
+    fn update(
+        id_value: i64,
+        unit_value: Cow<'a, str>,
+        description_value: Cow<'a, str>,
+        db: &SqliteConnection,
+    ) -> Result<()> {
+        use crate::schema::metric_keys::dsl::*;
+        diesel::update(metric_keys.filter(id.eq(id_value)))
+            .set((unit.eq(unit_value), description.eq(description_value)))
+            .execute(db)?;
+        Ok(())
+    }
     pub(crate) fn key_by_name(key_name: &str, db: &SqliteConnection) -> Result<MetricKey<'a>> {
         use crate::schema::metric_keys::dsl::metric_keys;
         match Self::key_by_name_inner(key_name, db) {
@@ -47,6 +80,7 @@ impl<'a> MetricKey<'a> {
                 let new_key = NewMetricKey {
                     key: Cow::Borrowed(key_name),
                     unit: Cow::Borrowed(""),
+                    description: Cow::Borrowed(""),
                 };
                 new_key.insert_into(metric_keys).execute(db)?;
                 // fetch it back out to get the ID

--- a/src/models.rs
+++ b/src/models.rs
@@ -53,9 +53,7 @@ impl<'a> MetricKey<'a> {
         let unit_value = unit
             .map(|u| Cow::Owned(u.as_str().to_string()))
             .unwrap_or(Cow::Borrowed(""));
-        let description = description
-            .map(|u| Cow::Borrowed(u))
-            .unwrap_or(Cow::Borrowed(""));
+        let description = description.map(Cow::Borrowed).unwrap_or(Cow::Borrowed(""));
         Self::update(key.id, unit_value, description, db)?;
         Ok(key)
     }
@@ -95,7 +93,7 @@ impl<'a> MetricKey<'a> {
         let keys = query.load::<MetricKey>(db)?;
         keys.into_iter()
             .next()
-            .ok_or(MetricsError::KeyNotFound(key_name.to_string()))
+            .ok_or_else(|| MetricsError::KeyNotFound(key_name.to_string()))
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,8 @@
 //! Diesel models of metrics sqlite storage
-use crate::schema::metrics;
+use crate::schema::{metric_keys, metrics};
+use crate::{MetricsError, Result};
+use diesel::prelude::*;
+use std::borrow::Cow;
 
 /// A new metric measurement for storing into sqlite database
 #[derive(Insertable, Debug)]
@@ -8,13 +11,63 @@ pub struct NewMetric {
     /// Timestamp of sample
     pub timestamp: f64,
     /// Key/name of sample
-    pub key: String,
+    pub metric_key_id: i64,
     /// Value of sample
     pub value: f64,
 }
 
+/// New metric key entry
+#[derive(Insertable, Debug)]
+#[table_name = "metric_keys"]
+pub struct NewMetricKey<'a> {
+    /// Actual key
+    pub key: Cow<'a, str>,
+    /// Unit if any
+    pub unit: Cow<'a, str>,
+}
+
+/// Metric key
+#[derive(Queryable, Debug, Identifiable)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub struct MetricKey<'a> {
+    /// primary key of metric key
+    pub id: i64,
+    /// Actual key
+    pub key: Cow<'a, str>,
+    /// Unit if any
+    pub unit: Cow<'a, str>,
+}
+impl<'a> MetricKey<'a> {
+    pub(crate) fn key_by_name(key_name: &str, db: &SqliteConnection) -> Result<MetricKey<'a>> {
+        use crate::schema::metric_keys::dsl::metric_keys;
+        match Self::key_by_name_inner(key_name, db) {
+            Ok(key) => Ok(key),
+            Err(MetricsError::KeyNotFound(_)) => {
+                // not stored yet so create an entry
+                let new_key = NewMetricKey {
+                    key: Cow::Borrowed(key_name),
+                    unit: Cow::Borrowed(""),
+                };
+                new_key.insert_into(metric_keys).execute(db)?;
+                // fetch it back out to get the ID
+                Self::key_by_name_inner(key_name, db)
+            }
+            Err(e) => Err(e),
+        }
+    }
+    fn key_by_name_inner(key_name: &str, db: &SqliteConnection) -> Result<MetricKey<'a>> {
+        use crate::schema::metric_keys::dsl::*;
+        let query = metric_keys.filter(key.eq(key_name));
+        let keys = query.load::<MetricKey>(db)?;
+        keys.into_iter()
+            .next()
+            .ok_or(MetricsError::KeyNotFound(key_name.to_string()))
+    }
+}
+
 /// Metric model for existing entries in sqlite database
-#[derive(Queryable, Debug)]
+#[derive(Queryable, Debug, Identifiable, Associations)]
+#[belongs_to(MetricKey<'_>)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Metric {
     /// Unique ID of sample
@@ -22,7 +75,7 @@ pub struct Metric {
     /// Timestamp of sample
     pub timestamp: f64,
     /// Key/name of sample
-    pub key: String,
+    pub metric_key_id: i64,
     /// Value of sample
     pub value: f64,
 }

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -40,18 +40,20 @@ impl Recorder for SqliteExporter {
     fn increment_counter(&self, key: Key, value: u64) {
         match SystemTime::UNIX_EPOCH.elapsed() {
             Ok(timestamp) => {
-                if let Err(e) = self
+                if let Err(_e) = self
                     .sender
                     .try_send(Event::IncrementCounter(timestamp, key, value))
                 {
+                    #[cfg(feature = "log_dropped_metrics")]
                     error!(
                         "Error sending metric to SQLite thread: {}, dropping metric",
-                        e
+                        _e
                     );
                 }
             }
-            Err(e) => {
-                error!("Failed to get system time: {}, dropping metric", e);
+            Err(_e) => {
+                #[cfg(feature = "log_dropped_metrics")]
+                error!("Failed to get system time: {}, dropping metric", _e);
             }
         }
     }
@@ -59,18 +61,20 @@ impl Recorder for SqliteExporter {
     fn update_gauge(&self, key: Key, value: GaugeValue) {
         match SystemTime::UNIX_EPOCH.elapsed() {
             Ok(timestamp) => {
-                if let Err(e) = self
+                if let Err(_e) = self
                     .sender
                     .try_send(Event::UpdateGauge(timestamp, key, value))
                 {
+                    #[cfg(feature = "log_dropped_metrics")]
                     error!(
                         "Error sending metric to SQLite thread: {}, dropping metric",
-                        e
+                        _e
                     );
                 }
             }
-            Err(e) => {
-                error!("Failed to get system time: {}, dropping metric", e);
+            Err(_e) => {
+                #[cfg(feature = "log_dropped_metrics")]
+                error!("Failed to get system time: {}, dropping metric", _e);
             }
         }
     }
@@ -78,18 +82,20 @@ impl Recorder for SqliteExporter {
     fn record_histogram(&self, key: Key, value: f64) {
         match SystemTime::UNIX_EPOCH.elapsed() {
             Ok(timestamp) => {
-                if let Err(e) = self
+                if let Err(_e) = self
                     .sender
                     .try_send(Event::UpdateHistogram(timestamp, key, value))
                 {
+                    #[cfg(feature = "log_dropped_metrics")]
                     error!(
                         "Error sending metric to SQLite thread: {}, dropping metric",
-                        e
+                        _e
                     );
                 }
             }
-            Err(e) => {
-                error!("Failed to get system time: {}, dropping metric", e);
+            Err(_e) => {
+                #[cfg(feature = "log_dropped_metrics")]
+                error!("Failed to get system time: {}, dropping metric", _e);
             }
         }
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -11,6 +11,7 @@ table! {
         id -> BigInt,
         key -> Text,
         unit -> Text,
+        description -> Text,
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -2,8 +2,15 @@ table! {
     metrics (id) {
         id -> BigInt,
         timestamp -> Double,
-        key -> Text,
+        metric_key_id -> BigInt,
         value -> Double,
+    }
+}
+table! {
+    metric_keys (id) {
+        id -> BigInt,
+        key -> Text,
+        unit -> Text,
     }
 }
 


### PR DESCRIPTION
- Normalizes the DB some by storing the metric keys separately & uses the IDs in the metrics table
- Also runs vacuum on startup as part of house keeping
- Supports `metrics` crate's registration APIs & stores the unit & description in SQLite
- Adds option to periodically clean data at runtime (by age and/or record limit)
  - NOTE: this may cause metrics to drop depending on how frequently you're trying to record them

Closes #2 