### PR TITLE
fix: CSV export didn't include key names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics-sqlite"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jeremy Knope <jeremy@astropad.com>"]
 description = "Library for providing SQLite backend for metrics"
 keywords = ["metrics", "sqlite"]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -14,5 +14,6 @@ table! {
         description -> Text,
     }
 }
-
+joinable!(metrics -> metric_keys (metric_key_id));
+allow_tables_to_appear_in_same_query!(metrics, metric_keys);
 // allow_tables_to_appear_in_same_query!(counters,);


### PR DESCRIPTION
CSV export didn't include key names but their IDs due to recent table changes, this fixes it to behave like it did before with key names in the CSV export