### PR TITLE
fix: upgrade to Rust 2024 edition (ENG-5091)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "metrics-sqlite"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Jeremy Knope <jeremy@astropad.com>"]
 description = "Library for providing SQLite backend for metrics"
 keywords = ["metrics", "sqlite"]
 categories = ["development-tools::debugging"]
-edition = "2018"
+edition = "2024"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 documentation = "https://docs.rs/metrics-sqlite"

--- a/examples/import_csv.rs
+++ b/examples/import_csv.rs
@@ -1,5 +1,5 @@
 use metrics_sqlite::MetricsDb;
-use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 fn main() {
     let fmt_layer = fmt::layer();

--- a/examples/large-file.rs
+++ b/examples/large-file.rs
@@ -2,7 +2,7 @@ use metrics::{counter, gauge};
 use metrics_sqlite::SqliteExporter;
 use std::time::Duration;
 use tracing_subscriber::prelude::*;
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt};
 
 fn setup_metrics() {
     let exporter = SqliteExporter::new(

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
 use metrics::{counter, gauge};
 use metrics_sqlite::SqliteExporter;
 use std::time::Duration;
-use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 fn setup_metrics() {
     let exporter = SqliteExporter::new(

--- a/examples/summary.rs
+++ b/examples/summary.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use chrono::{DateTime, Local, TimeZone};
 use clap::Parser;
 use metrics_sqlite::MetricsDb;
-use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Parser)]
 struct Args {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,10 +352,13 @@ fn run_worker(
                 // Check if we need to flush based on elapsed time
                 let time_based_flush = state.last_flush.elapsed() >= flush_duration;
 
-                let (should_flush, should_exit) = match receiver.recv_timeout(flush_duration) {
+                let mut should_flush = false;
+                let mut should_exit = false;
+                match receiver.recv_timeout(flush_duration) {
                     Ok(Event::Stop) => {
                         info!("Stopping SQLiteExporter worker, flushing & exiting");
-                        (true, true)
+                        should_flush = true;
+                        should_exit = true;
                     }
                     Ok(Event::SetHousekeeping {
                         retention_period,
@@ -363,7 +366,6 @@ fn run_worker(
                         record_limit,
                     }) => {
                         state.set_housekeeping(retention_period, housekeeping_period, record_limit);
-                        (false, false)
                     }
                     Ok(Event::DescribeKey(_key_type, key, unit, desc)) => {
                         info!("Describing key {:?}", key);
@@ -375,11 +377,9 @@ fn run_worker(
                         ) {
                             error!("Failed to create key entry: {:?}", e);
                         }
-                        (false, false)
                     }
                     Ok(Event::RegisterKey(_key_type, _key, _handle)) => {
                         // we currently don't do anything with register...
-                        (false, false)
                     }
                     Ok(Event::IncrementCounter(timestamp, key, value)) => {
                         let key_name = key.name();
@@ -391,8 +391,7 @@ fn run_worker(
                         if let Err(e) = state.queue_metric(timestamp, key_name, value as _) {
                             error!("Error queueing metric: {:?}", e);
                         }
-
-                        (state.should_flush(), false)
+                        should_flush = state.should_flush();
                     }
                     Ok(Event::AbsoluteCounter(timestamp, key, value)) => {
                         let key_name = key.name();
@@ -400,7 +399,7 @@ fn run_worker(
                         if let Err(e) = state.queue_metric(timestamp, key_name, value as _) {
                             error!("Error queueing metric: {:?}", e);
                         }
-                        (state.should_flush(), false)
+                        should_flush = state.should_flush();
                     }
                     Ok(Event::UpdateGauge(timestamp, key, value)) => {
                         let key_name = key.name();
@@ -422,15 +421,14 @@ fn run_worker(
                         if let Err(e) = state.queue_metric(timestamp, key_name, value) {
                             error!("Error queueing metric: {:?}", e);
                         }
-                        (state.should_flush(), false)
+                        should_flush = state.should_flush();
                     }
                     Ok(Event::UpdateHistogram(timestamp, key, value)) => {
                         let key_name = key.name();
                         if let Err(e) = state.queue_metric(timestamp, key_name, value) {
                             error!("Error queueing metric: {:?}", e);
                         }
-
-                        (state.should_flush(), false)
+                        should_flush = state.should_flush();
                     }
                     Ok(Event::RequestSummaryFromSignpost {
                         signpost_key,
@@ -468,16 +466,16 @@ fn run_worker(
                                 }
                             }
                         }
-                        (false, false)
                     }
                     Err(RecvTimeoutError::Timeout) => {
-                        (true, false)
+                        should_flush = true;
                     }
                     Err(RecvTimeoutError::Disconnected) => {
                         warn!("SQLiteExporter channel disconnected, exiting worker");
-                        (true, true)
+                        should_flush = true;
+                        should_exit = true;
                     }
-                };
+                }
 
                 // Flush if time-based flush is triggered OR if event-based flush is triggered
                 if time_based_flush || should_flush {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -585,11 +585,11 @@ impl SqliteExporter {
                         let excess = records - record_limit + (record_limit / 4); // delete excess + 25% of limit
                         trace!(
                             "Exceeded limit! {} > {}, deleting {} oldest",
-                            records,
-                            record_limit,
-                            excess
+                            records, record_limit, excess
                         );
-                        let query = format!("DELETE FROM metrics WHERE id IN (SELECT id FROM metrics ORDER BY timestamp ASC LIMIT {excess});");
+                        let query = format!(
+                            "DELETE FROM metrics WHERE id IN (SELECT id FROM metrics ORDER BY timestamp ASC LIMIT {excess});"
+                        );
                         if let Err(e) = sql_query(query).execute(db) {
                             error!("Failed to delete excessive records: {:?}", e);
                         }

--- a/src/metrics_db.rs
+++ b/src/metrics_db.rs
@@ -1,7 +1,8 @@
 //! Metrics DB, to use/query/etc metrics SQLite databases
 use super::{
+    MetricsError, Result,
     models::{Metric, MetricKey},
-    setup_db, MetricsError, Result,
+    setup_db,
 };
 use diesel::prelude::*;
 #[cfg(feature = "import_csv")]
@@ -205,7 +206,7 @@ impl MetricsDb {
                     error!("Skipping record due to error reading CSV record: {:?}", e);
                 }
             }
-            if flush_counter.is_multiple_of(200) {
+            if flush_counter % 200 == 0 {
                 trace!("Flushing");
                 inner.flush()?;
             }

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -4,7 +4,7 @@ use metrics::{
     Recorder, SharedString, Unit,
 };
 use std::{
-    sync::{mpsc::SyncSender, Arc},
+    sync::{Arc, mpsc::SyncSender},
     time::SystemTime,
 };
 use tracing::error;


### PR DESCRIPTION
## Summary
- Upgrades from Rust edition 2018 to 2024, fixing 3 `tail_expr_drop_order` deprecation warnings
- Refactors the worker event loop match from a tail expression into mutable variable assignments so temporaries drop at the end of each match arm
- Bumps version to 0.6.0 (MSRV change is breaking) and sets `rust-version = "1.85"`

## Test plan
- [x] `cargo check` passes with zero warnings
- [x] `RUSTFLAGS="-W rust-2024-compatibility" cargo check` passes clean
- [x] `cargo test` — all 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)